### PR TITLE
Feature/fix users code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Metrics/LineLength:
 AsciiComments:
   Enabled: false
 
+# モジュール名::クラス名の許可
+ClassAndModuleChildren:
+  Enabled: false
+
 # Windows環境で発生する改行エラーに対応
 # CircleCIでrubocopを利用するときはcrlfをlfに変更しないとエラーが出るらしいので注意
 Layout/EndOfLine:

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -41,23 +41,5 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # redirect_to new_user_registration_url
       # ↑ ログインすることになるので以下のように修正
     end
-end
-
-  private
-
-  def callback_from(provider)
-    provider = provider.to_s
-
-    @user = User.find_for_oauth(request.env['omniauth.auth'])
-
-    if @user.persisted?
-      print('persisted true')
-      flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: provider.capitalize)
-      sign_in_and_redirect @user, event: :authentication
-    else
-      print('persisted false')
-      session["devise.#{provider}_data"] = request.env['omniauth.auth']
-      redirect_to controller: 'sessions', action: 'new'
-    end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -31,15 +31,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def twitter
     @user = User.from_omniauth(request.env['omniauth.auth'].except('extra'))
 
-    if @user.persisted?
-      sign_in_and_redirect @user
-    else
+    unless @user.persisted?
       @user.skip_confirmation!
       @user.save!
-      # session["devise.user_attributes"] = @user.attributes
-      # ↑ 認証データを覚える必要はないので削除
-      # redirect_to new_user_registration_url
-      # ↑ ログインすることになるので以下のように修正
     end
+    sign_in_and_redirect @user
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -40,7 +40,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # ↑ 認証データを覚える必要はないので削除
       # redirect_to new_user_registration_url
       # ↑ ログインすることになるので以下のように修正
-      sign_in_and_redirect @user
     end
 end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,18 +4,10 @@ class UsersController < ApplicationController
   before_action :require_sign_in
 
   def show
-    if User.find_by(id: params[:id]).nil?
-      redirect_to root_path
-    else
-      @user = User.find(params[:id])
-      @subs = @user.books.page(params[:page]).per(15)
-      @reviews = Review.where(user_id: params[:id])
-      @favs = @user.favbooks.page(params[:page]).per(10)
-      @user.books
-      @recently_subs_id = @user.subscribes.order('id DESC').limit(4).select('book_id')
-      @subs_series = @user.books.group(:series).count.sort
-      @favs_series = @user.favbooks.group(:series).count.sort
-    end
+    redirect_to root_path if User.find_by(id: params[:id]).nil?
+
+    @user = User.find(params[:id])
+    @reviews = Review.where(user_id: params[:id])
   end
 
   def edit
@@ -39,6 +31,7 @@ class UsersController < ApplicationController
   end
 
   private
+
   def require_sign_in
     return if user_signed_in?
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  before_action :require_sign_in
+
   def show
-    unless user_signed_in?
-      flash[:warning] = 'ユーザーページをみるにはログインが必要です。'
-      redirect_to user_session_path
-    end
     if User.find_by(id: params[:id]).nil?
       redirect_to root_path
     else
@@ -21,15 +19,11 @@ class UsersController < ApplicationController
   end
 
   def edit
-    if user_signed_in?
-      if current_user.id.to_s == params[:id]
-        @user = User.find(params[:id])
-      else
-        redirect_to root_path
-        flash[:danger] = '編集する権限がありません。'
-      end
+    if current_user.id.to_s == params[:id]
+      @user = User.find(params[:id])
     else
-      redirect_to user_session_path
+      redirect_to root_path
+      flash[:danger] = '編集する権限がありません。'
     end
   end
 
@@ -45,8 +39,13 @@ class UsersController < ApplicationController
   end
 
   private
+  def require_sign_in
+    return if user_signed_in?
 
-  # Strong Parameter
+    flash[:warning] = 'このページをみるにはログインが必要です。'
+    redirect_to user_session_path
+  end
+
   def user_params
     params.require(:user).permit(:name, :image, :profile)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[0, 20]
       user.email = User.dumy_email(auth)
     end
- end
+  end
 
   def self.new_with_session(params, session)
     if session['devise.user_attributes']
@@ -81,8 +81,6 @@ class User < ApplicationRecord
   end
 
   mount_uploader :image, ImageUploader
-
-  private
 
   def self.dumy_email(auth)
     "#{auth.uid}-#{auth.provider}@example.com"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
     </div>
     <div class="collapse" id="collapsesubs">
       <div class="row">
-      <% @recently_subs_id.each do |id| %>
+      <% @user.subscribes.order('id DESC').limit(4).select('book_id').each do |id| %>
         <%= render 'books/book_card_small', book: id.book %>
       <% end %>
       </div>
@@ -46,7 +46,7 @@
 
 
     <div class="row">
-    <% @subs_series.each do |comic,count| %>
+    <% @user.books.group(:series).count.sort.each do |comic,count| %>
       <div class="col-md-6">
         <% escape_comic = comic.gsub(/\.|\!/,"") %>
         <a class="btn btn-dark btn-block text-left d-flex justify-content-between align-items-center" data-toggle="collapse" href="#collapse<%= escape_comic %>" role="button" aria-expanded="false" aria-controls="collapse<%= escape_comic %>">
@@ -74,9 +74,8 @@
       <br>
     </div>
     <div class="collapse" id="collapsesubs">
-      <% recently_favs_id = @user.favorites.order("id DESC").limit(4).select("book_id") %>
       <div class="row">
-        <% recently_favs_id.each do |id| %>
+        <% @user.favorites.order("id DESC").limit(4).select("book_id").each do |id| %>
           <%= render 'books/book_card_small', book: id.book %>
         <% end %>
       </div>
@@ -86,7 +85,7 @@
   <% end %>
 
 <div class="row" id="favzone">
-<% @favs_series.each do |comic,count| %>
+<% @user.favbooks.group(:series).count.sort.each do |comic,count| %>
   <div class="col-md-6">
   <% escape_comic = comic.sub(/\./,"") %>
     <a class="btn btn-dark btn-block text-left d-flex justify-content-between align-items-center" data-toggle="collapse" href="#collapse<%= escape_comic %>" role="button" aria-expanded="false" aria-controls="collapse<%= escape_comic %>">


### PR DESCRIPTION
# 変更点
usersコントローラーの整形
- ログイン要求を共通化
- 各アクションの不要な変数を削除し、Viewに反映
- rubocopにてモジュール名::クラス名を許可する設定を追加
- Twitter連携ログインにある不要な書き残しを削除し、リダイレクトの記述の冗長性を修正
