### PR TITLE
Feature/add series publisher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - tmp/**/*
     - config/environments/*
     - spec/models/*
+    - app/helpers/users_helper.rb
 
 Rails:
   Enabled: true

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -18,7 +18,6 @@ module UsersHelper
               'btn-secondary'
             when '少年画報社'
               'btn-info'
-
             else
               'btn-dark'
             end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module UsersHelper
   def get_color(comic)
     publisher = Bookseries.find_by(title: comic).publisher

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,27 @@
+module UsersHelper
+  def get_color(comic)
+    publisher = Bookseries.find_by(title: comic).publisher
+    color = case publisher
+            when '集英社'
+              'btn-primary'
+            when '小学館'
+              'btn-outline-dark'
+            when '講談社'
+              'btn-success'
+            when '竹書房'
+              'btn-danger'
+            when '新潮社'
+              'btn-warning'
+            when '双葉社'
+              'btn-light'
+            when '秋田書店'
+              'btn-secondary'
+            when '少年画報社'
+              'btn-info'
+
+            else
+              'btn-dark'
+            end
+    color
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -39,7 +39,7 @@ class Book < ApplicationRecord
   def set_series
     return unless Bookseries.find_by(title: series).nil?
 
-    bookseries = Bookseries.new(title: series)
+    bookseries = Bookseries.new(title: series, publisher: publisherName)
     bookseries.save
   end
 

--- a/app/models/bookseries.rb
+++ b/app/models/bookseries.rb
@@ -4,4 +4,5 @@ class Bookseries < ApplicationRecord
   has_many :books
   validates :title, presence: true
   validates :title, uniqueness: true
+  validates :publisher, presence: true
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
       <div class="col-lg-4 col-md-6">
         <%= form_with url: user_path, method: :get do |f| %>
           <%= hidden_field_tag :sub_series_title, comic %>
-          <input value="<%= comic %>" type="submit" class="mb-2 btn btn-dark btn-block text-left d-flex justify-content-between align-items-center" data-toggle="modal" data-target="#Modal">
+          <input value="<%= comic %>" type="submit" class="mb-2 btn <%= get_color(comic) %> btn-block text-left d-flex justify-content-between align-items-center" data-toggle="modal" data-target="#Modal">
         <% end %>
       </div>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,9 @@
 
 <!--タブコンテンツ部分-->
 <div class="tab-content">
+
   <div id="tab1" class="tab-pane active pt-2">
+  <% if @user.books.present? %>
   <p>出版社毎に色分けして表示されます。</p>
   <div class="row">
     <% @user.books.group(:series).count.sort.each do |comic,count| %>
@@ -34,6 +36,9 @@
       </div>
     <% end %>
     </div>
+    <% else %>
+      <p>まだ漫画を登録していません。</p>
+    <% end %>
   </div>
 
   <div class="modal fade" id="Modal" tabindex="-1" role="dialog" aria-labelledby="Modal" aria-hidden="true">
@@ -57,8 +62,10 @@
       </div>
     </div>
   </div>
-    
+
+
   <div id="tab2" class="tab-pane pt-2">
+  <% if @user.books.present? %>
   <p>出版社毎に色分けして表示されます。</p>
   <div class="row" id="favzone">
     <% @user.favbooks.group(:series).count.sort.each do |comic,count| %>
@@ -70,6 +77,9 @@
       </div>
     <% end %>
     </div>
+    <% else %>
+      <p>まだ漫画をお気に入り登録していません。</p>
+    <% end %>
   </div>
 
   <div class="modal fade" id="Modalfav" tabindex="-1" role="dialog" aria-labelledby="Modal" aria-hidden="true">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
 <!--タブコンテンツ部分-->
 <div class="tab-content">
   <div id="tab1" class="tab-pane active pt-2">
-
+  <p>出版社毎に色分けして表示されます。</p>
   <div class="row">
     <% @user.books.group(:series).count.sort.each do |comic,count| %>
       <div class="col-lg-4 col-md-6">
@@ -59,7 +59,7 @@
   </div>
     
   <div id="tab2" class="tab-pane pt-2">
-
+  <p>出版社毎に色分けして表示されます。</p>
   <div class="row" id="favzone">
     <% @user.favbooks.group(:series).count.sort.each do |comic,count| %>
       <div class="col-lg-4 col-md-6">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -65,7 +65,7 @@
       <div class="col-lg-4 col-md-6">
         <%= form_with url: user_path, method: :get do |f| %>
           <%= hidden_field_tag :fav_series_title, comic %>
-          <input value="<%= comic %>" type="submit" class="mb-2 btn btn-dark btn-block text-left d-flex justify-content-between align-items-center" data-toggle="modal" data-target="#Modalfav">
+          <input value="<%= comic %>" type="submit" class="mb-2 btn <%= get_color(comic) %> btn-block text-left d-flex justify-content-between align-items-center" data-toggle="modal" data-target="#Modalfav">
         <% end %>
       </div>
     <% end %>

--- a/db/migrate/20191205043059_add_publisher_to_bookseries.rb
+++ b/db/migrate/20191205043059_add_publisher_to_bookseries.rb
@@ -1,0 +1,5 @@
+class AddPublisherToBookseries < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookseries, :publisher, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_08_042142) do
+ActiveRecord::Schema.define(version: 2019_12_05_043059) do
 
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2019_11_08_042142) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "publisher"
   end
 
   create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/addcolumn/publisher_series.rb
+++ b/lib/addcolumn/publisher_series.rb
@@ -1,0 +1,6 @@
+
+Bookseries.all.each do |series|
+  if series.publisher.nil?
+    series.update(publisher: Book.find_by(series: series.title).publisherName)
+  end
+end

--- a/lib/addcolumn/publisher_series.rb
+++ b/lib/addcolumn/publisher_series.rb
@@ -1,6 +1,5 @@
+# frozen_string_literal: true
 
 Bookseries.all.each do |series|
-  if series.publisher.nil?
-    series.update(publisher: Book.find_by(series: series.title).publisherName)
-  end
+  series.update(publisher: Book.find_by(series: series.title).publisherName) if series.publisher.nil?
 end

--- a/spec/factories/bookseries.rb
+++ b/spec/factories/bookseries.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :bookseries do
     title { 'hogehoge' }
+    publisher { 'abc' }
   end
 end

--- a/spec/models/bookseries_spec.rb
+++ b/spec/models/bookseries_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe Bookseries, type: :model do
     bookseries.valid?
     expect(bookseries.errors[:title]).to include('はすでに存在します')
   end
+
+  it 'publisherがないときは無効であること' do
+    bookseries = FactoryBot.build(:bookseries, publisher: nil)
+    bookseries.valid?
+    expect(bookseries.errors[:publisher]).to include('を入力してください')
+  end
 end


### PR DESCRIPTION
# 変更点
- Bookseriesに出版社名カラム追加
- Bookseries作成時、本の出版社名でpublisherを埋めるように追加
- 既存のBookseriesのpublisherを埋めるrunner用のファイルを作成
- 登録漫画をシリーズ出版社毎に色分け
- 色分けしているというコメントを追加
- ユーザーページにて登録しているものがないときに何もないというメッセージを追加